### PR TITLE
Travis: fix version tag in archive name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
     - export GOARCH=${PLATFORM#*/}
     
     # Analyze, test and build the code, and then package the binary
-    - make verify release
+    - make verify release APP_VER=$TRAVIS_TAG
 
 deploy:
     


### PR DESCRIPTION
Fixes a bug in which the archive name was always created with a `0.1` version, regardless of the actual tag.