### PR TITLE
Removed check for 0.0 probability abort and delay

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -426,11 +426,6 @@ func validateRule(rule resources.Rule) error {
 		return &InvalidRuleError{Reason: "invalid delay", ErrorMessage: "invalid_delay"}
 	}
 
-	// Ensure abort or delay is set
-	if rule.DelayProbability == 0.0 && rule.AbortProbability == 0.0 {
-		return &InvalidRuleError{Reason: "invalid rule", ErrorMessage: "invalid_rule"}
-	}
-
 	// Validate header
 	if rule.Header == "" {
 		return &InvalidRuleError{Reason: "invalid header", ErrorMessage: "invalid_header"}


### PR DESCRIPTION
Allows for NOP rules to be added for logging purposes. This will be implemented in a more native way in 0.3.