### PR TITLE
Fixed logic to update 'last_updated' field on changes to the rules

### DIFF
--- a/nginx/generator.go
+++ b/nginx/generator.go
@@ -60,7 +60,7 @@ func (g *generator) Generate(id string, lastUpdate *time.Time) (*resources.NGINX
 		return nil, err
 	}
 
-	if lastUpdate != nil && entry.ServiceCatalog.LastUpdate.After(*lastUpdate) {
+	if lastUpdate != nil && lastUpdate.After(entry.ServiceCatalog.LastUpdate) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Before this fix changes to the tenant configuration would not trigger an update of the 'last_updated' field. This meant that tenants polling for configuration would be comparing when they last updated against an out of date timestamp and would not pick up new configurations.